### PR TITLE
Fix excessive tab opening in data retrieval logic

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,7 +2,7 @@ const STORAGE_KEY = 'amz_spending_cache';
 const CACHE_TIME = 1000 * 60 * 30;
 
 async function scrapeSinglePage(filter, startIndex = 0) {
-  let url = `https://www.amazon.it/your-orders/orders?timeFilter=${filter}`;
+  let url = `https://www.amazon.it/your-orders/orders?timeFilter=${filter}&_scraping=1`;
   if (startIndex > 0) {
     url += `&startIndex=${startIndex}`;
   }

--- a/content.js
+++ b/content.js
@@ -214,6 +214,9 @@ function injectPopup(data) {
 }
 
 async function init() {
+  // Skip if this is a scraping tab opened by background.js
+  if (window.location.href.includes('_scraping=1')) return;
+
   if (
     window.location.href.includes('signin') ||
     window.location.href.includes('checkout')


### PR DESCRIPTION
Add _scraping=1 parameter to URLs opened for data scraping and skip content script initialization on these tabs. This prevents each scraping tab from triggering additional GET_SPENDING requests.